### PR TITLE
Make job status and result available without authentication

### DIFF
--- a/src/API/REST/routes/get_job.ts
+++ b/src/API/REST/routes/get_job.ts
@@ -1,13 +1,12 @@
 import express from "express";
 import {ExtRequest} from "../../../definitions/ext_request";
 import {projectModel} from "../../../database/models/project";
-import check_auth from "../middleware/check_auth";
 
 export default function get_job_route() {
   let router = express.Router();
 
   router
-    .get("/job/:id", check_auth(), async (req: ExtRequest, res: any) => {
+    .get("/job/:id", async (req: ExtRequest, res: any) => {
       const jobId = req.params.id;
       const job = await projectModel.findById(jobId);
 


### PR DESCRIPTION
This is probably not a good practice but we need a result page (with some basic info about the job) to be available to anyone (including people without an account) and this is probably the quickest solution now.